### PR TITLE
chore(ci): run release workflow everyday 3:00

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: release
 
 on:
   schedule:
-    - cron: "0 3 * * MON"
+    - cron: "0 3 * * *"
   workflow_dispatch:
 
 jobs:
@@ -16,3 +16,6 @@ jobs:
       - uses: go-semantic-release/action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # This option starts version from 0.1.0, when master version
+          # bigger or equal to 1, this option will be ignored.
+          allow-initial-development-versions: true


### PR DESCRIPTION
- enable `allow-initial-development-versions` option, refer to
https://github.com/go-semantic-release/action?tab=readme-ov-file#arguments
